### PR TITLE
Fixed makefile parsing issue that failed to stop at EOF

### DIFF
--- a/projects/MakefileEngine/MakefileEngineProject.cpp
+++ b/projects/MakefileEngine/MakefileEngineProject.cpp
@@ -161,7 +161,7 @@ BString
 MakefileEngineProject::_ParseString(BString& mkfile, int32& pos)
 {
 	BString str;
-	while (mkfile[pos] != '\n' && mkfile[pos] != '=' && mkfile[pos] != ':') {
+	while (mkfile[pos] != '\n' && mkfile[pos] != '=' && mkfile[pos] != ':' && mkfile[pos] != '\0') {
 		if (mkfile[pos] == '\\')
 			pos++; // Skip next character, probably a newline
 		else


### PR DESCRIPTION
Latest change to the Makefile included "DEVELOP_DIRECTORY" which is an expression the parser searches for. In doing so, it tried to parse the string from this point and failed to account for the null terminator, and hence failed to stop at the end of the string.